### PR TITLE
Kkjj 23 항공 구매 서비스 구상

### DIFF
--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/controller/AirPurchaseAdminController.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/controller/AirPurchaseAdminController.java
@@ -1,0 +1,49 @@
+package renewal.awesome_travel_backoffice.airPurchase.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import renewal.awesome_travel_backoffice.airPurchase.dto.request.AirPurchaseSearchCondition;
+import renewal.awesome_travel_backoffice.airPurchase.dto.response.AirPurchaseResponseDto;
+import renewal.awesome_travel_backoffice.airPurchase.service.AirPurchaseService;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/air-purchases")
+public class AirPurchaseAdminController {
+
+    private final AirPurchaseService airPurchaseService;
+
+    // 1. 전체 목록 조회 (페이징 + 정렬)
+    @GetMapping
+    public ResponseEntity<Page<AirPurchaseResponseDto>> getAllPurchases(
+            @ModelAttribute AirPurchaseSearchCondition condition,
+            @PageableDefault(size = 20, sort = "purchaseDate", direction = Sort.Direction.DESC)
+            Pageable pageable
+    ) {
+        Page<AirPurchaseResponseDto> result = airPurchaseService.getAllPurchases(condition, pageable);
+        return ResponseEntity.ok(result);
+    }
+
+
+    // 2. 단건 상세 조회
+    @GetMapping("/{id}")
+    public ResponseEntity<AirPurchaseResponseDto> getPurchase(@PathVariable Long id) {
+        return ResponseEntity.ok(airPurchaseService.getPurchase(id));
+    }
+
+    // 3. 상태 변경 (관리자용)
+    @PatchMapping("/{id}/status")
+    public ResponseEntity<Void> changeStatus(
+            @PathVariable Long id,
+            @RequestParam PurchaseStatus status
+    ) {
+        airPurchaseService.changePurchaseStatus(id, status);
+        return ResponseEntity.ok().build();
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/request/AirPurchaseSearchCondition.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/request/AirPurchaseSearchCondition.java
@@ -1,0 +1,25 @@
+package renewal.awesome_travel_backoffice.airPurchase.dto.request;
+
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+
+import java.time.LocalDate;
+
+@Getter
+@Setter
+public class AirPurchaseSearchCondition {
+
+    private PurchaseStatus status;        // 상태 필터 (예: HOLDING, PAID)
+
+    private String name;                  // 예약자 이름 (부분 검색)
+
+    private String email;                 // 예약자 이메일 (정확 or 부분)
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate startDate;         // 예약일 시작
+
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE)
+    private LocalDate endDate;           // 예약일 종료
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/response/AirPassengerResponseDto.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/response/AirPassengerResponseDto.java
@@ -1,0 +1,30 @@
+package renewal.awesome_travel_backoffice.airPurchase.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AirPassengerResponseDto {
+
+    private String name;
+    private String number;
+    private String email;
+    private LocalDate birth;
+    private String sex;
+    private String nationality;  // 예: "KOR"
+    private String passportNum;
+    private String lastName;
+    private String firstName;
+    private LocalDate expire;
+
+    private List<String> specialRequests; // "Wheelchair", "Vegetarian" 등
+}
+

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/response/AirPurchaseResponseDto.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/response/AirPurchaseResponseDto.java
@@ -1,0 +1,40 @@
+package renewal.awesome_travel_backoffice.airPurchase.dto.response;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class AirPurchaseResponseDto {
+
+    private Long id;
+
+    private AirResponseOneDto airDto; // 기존 AirDto → AirResponseDto 로 변경
+
+    private PurchaseStatus status;
+
+    private Integer price;
+
+    private Long member_id;
+
+    private String name;
+
+    private String number;
+
+    private String email;
+
+    private LocalDateTime purchaseDate;
+
+    private LocalDateTime paymentDueDate;
+
+    private List<AirPassengerResponseDto> airPassengers;
+}
+

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/response/AirResponseOneDto.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/dto/response/AirResponseOneDto.java
@@ -1,0 +1,32 @@
+package renewal.awesome_travel_backoffice.airPurchase.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+import renewal.awesome_travel_backoffice.air.utiles.FlightType;
+import renewal.awesome_travel_backoffice.air.utiles.SeatClassType;
+
+@Getter
+@Builder
+public class AirResponseOneDto {
+    private Long airId;
+    private String code;
+
+    //항공사정보
+    private String airlineCode;
+    private String airlineNameKor;
+    private String airlineNameEng;
+
+    private String depart;
+    private String arrive;
+    private String departTime;
+    private String arriveTime;
+    private int stopovers;
+    private FlightType flightType;
+
+    // 단일 좌석 정보
+    private Long seatClassId;
+    private SeatClassType seatClassType;
+    private Integer price;
+    private Integer availableSeats;
+}
+

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/AirPassenger.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/AirPassenger.java
@@ -1,0 +1,39 @@
+package renewal.awesome_travel_backoffice.airPurchase.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.Sex;
+import renewal.awesome_travel_backoffice.country.entity.Country;
+import renewal.awesome_travel_backoffice.specialRequest.entity.SpecialRequest;
+
+import java.time.LocalDate;
+import java.util.HashSet;
+import java.util.Set;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "AirPassenger")
+public class AirPassenger extends BasePassenger {
+
+    @ManyToOne
+    @JoinColumn(name = "air_purchase_id", nullable = false)
+    private AirPurchase airPurchase;
+
+    //요구사항(기내식, 좌석, 수하물 등등) 추후 enum이나 엔티티로 변경
+    @ManyToMany
+    @JoinTable(
+            name = "air_passenger_special_requests",
+            joinColumns = @JoinColumn(name = "air_passenger_id"),
+            inverseJoinColumns = @JoinColumn(name = "special_request_id")
+    )
+    private Set<SpecialRequest> specialRequests = new HashSet<>(); //요구사항
+
+    public AirPassenger(AirPurchase airPurchase, String name, String number, String email, LocalDate birth, Sex sex, Country nationality, String passport_num, String lastName, String firstName, LocalDate expire) {
+        super(name, number, email, birth, sex, nationality, passport_num, lastName, firstName, expire);
+        this.airPurchase = airPurchase;
+    }
+
+
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/AirPurchase.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/AirPurchase.java
@@ -1,0 +1,43 @@
+package renewal.awesome_travel_backoffice.airPurchase.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import renewal.awesome_travel_backoffice.air.entity.SeatClass;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "AirPurchase")
+public class AirPurchase extends BasePurchase {
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "seat_class_id", nullable = false)
+    private SeatClass seatClass;
+
+    @OneToMany(mappedBy = "airPurchase", cascade = CascadeType.ALL, orphanRemoval = true)
+    private List<AirPassenger> airPassengers = new ArrayList<>();
+
+    public AirPurchase(SeatClass seatClass, Integer price, Long member_id, String name, String number, String email, LocalDateTime purchaseDate, LocalDateTime paymentDueDate) {
+        super(price, member_id, name, number, email, purchaseDate, paymentDueDate);
+        this.seatClass = seatClass;
+
+    }
+
+    public void setPurchaseStatus(PurchaseStatus newStatus) {
+        // 상태가 이미 PAID인데 다시 HOLDING으로 바꾸려는 경우 방지
+        if (this.purchaseStatus == PurchaseStatus.PAID && newStatus == PurchaseStatus.HOLDING) {
+            throw new IllegalStateException("결제 완료된 구매는 HOLDING 상태로 되돌릴 수 없습니다.");
+        }
+        if (this.purchaseStatus == PurchaseStatus.CANCELLED && newStatus != PurchaseStatus.CANCELLED) {
+            throw new IllegalStateException("취소된 구매는 상태를 변경할 수 없습니다.");
+        }
+
+        this.purchaseStatus = newStatus;
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/BasePassenger.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/BasePassenger.java
@@ -1,0 +1,71 @@
+package renewal.awesome_travel_backoffice.airPurchase.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.Sex;
+import renewal.awesome_travel_backoffice.country.entity.Country;
+
+import java.time.LocalDate;
+
+@Getter
+@NoArgsConstructor
+@MappedSuperclass
+public abstract class   BasePassenger {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    protected  Long id;
+
+    //국내 국제 필수 입력값
+    @Column(nullable = false)
+    protected  String name; //풀네임 (한국인>한글, 외국인>영문)
+
+    @Column(nullable = false)
+    protected  String number; //전화번호
+
+    @Column(nullable = false)
+    protected  String email; //이메일
+
+    @Column(nullable = false)
+    protected  LocalDate birth; //생년월일
+
+    @Column(nullable = false)
+    @Enumerated(EnumType.STRING)
+    protected Sex sex; //성별
+
+    @ManyToOne
+    @JoinColumn(name = "nationality_code", referencedColumnName = "countryCode", nullable = false)
+    protected Country nationality; //국적 REPUBLIC OF KOREA
+
+    //국제선
+    @Column(nullable = true)
+    protected  String passport_num; //여권번호
+
+    @Column(nullable = true)
+    protected  String lastName; //영문 성
+
+    @Column(nullable = true)
+    protected  String firstName; //영문 이름
+
+    @Column(nullable = true)
+    protected  LocalDate expire; //만료일
+
+    public BasePassenger(String name, String number, String email, LocalDate birth, Sex sex, Country nationality, String passport_num, String lastName, String firstName, LocalDate expire) {
+        this.name = name;
+        this.number = number;
+        this.email = email;
+        this.birth = birth;
+        this.sex = sex;
+        this.nationality = nationality;
+        this.passport_num = passport_num;
+        this.lastName = lastName;
+        this.firstName = firstName;
+        this.expire = expire;
+    }
+
+    public void setNationality(Country nationality) {
+        this.nationality = nationality;
+    }
+
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/BasePurchase.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/entity/BasePurchase.java
@@ -1,0 +1,56 @@
+package renewal.awesome_travel_backoffice.airPurchase.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+
+import java.time.LocalDateTime;
+
+@Getter
+@NoArgsConstructor
+@MappedSuperclass
+public abstract class BasePurchase {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "product_purchase_id")
+    protected Long id;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    protected PurchaseStatus purchaseStatus;
+
+
+    @Column(nullable = false)
+    protected Integer price; //결제금액
+
+    @Column(nullable = false)
+    protected Long member_id; //구매자
+
+    @Column(nullable = false)
+    protected String name;
+
+    @Column(nullable = false)
+    protected String number;
+
+    @Column(nullable = false)
+    protected String email;
+
+    @Column(nullable = false)
+    protected LocalDateTime purchaseDate; //구매일
+
+    @Column
+    protected LocalDateTime paymentDueDate; //결제기한
+
+    public BasePurchase(Integer price, Long member_id, String name, String number, String email, LocalDateTime purchaseDate, LocalDateTime paymentDueDate) {
+        this.price = price;
+        this.member_id = member_id;
+        this.name = name;
+        this.number = number;
+        this.email = email;
+        this.purchaseDate = purchaseDate;
+        this.paymentDueDate = paymentDueDate;
+    }
+
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/repository/AirPurchaseRepository.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/repository/AirPurchaseRepository.java
@@ -1,0 +1,20 @@
+package renewal.awesome_travel_backoffice.airPurchase.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import renewal.awesome_travel_backoffice.airPurchase.entity.AirPurchase;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+
+import java.time.LocalDateTime;
+
+public interface AirPurchaseRepository extends JpaRepository<AirPurchase, Long>, AirPurchaseRepositoryCustom {
+
+    Page<AirPurchase> findByPurchaseStatusAndPaymentDueDateBefore(
+            PurchaseStatus status,
+            LocalDateTime time,
+            Pageable pageable
+    );
+
+
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/repository/AirPurchaseRepositoryCustom.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/repository/AirPurchaseRepositoryCustom.java
@@ -1,0 +1,10 @@
+package renewal.awesome_travel_backoffice.airPurchase.repository;
+
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import renewal.awesome_travel_backoffice.airPurchase.dto.request.AirPurchaseSearchCondition;
+import renewal.awesome_travel_backoffice.airPurchase.entity.AirPurchase;
+
+public interface AirPurchaseRepositoryCustom {
+    Page<AirPurchase> searchByCondition(AirPurchaseSearchCondition condition, Pageable pageable);
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/repository/AirPurchaseRepositoryCustomImpl.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/repository/AirPurchaseRepositoryCustomImpl.java
@@ -1,0 +1,57 @@
+package renewal.awesome_travel_backoffice.airPurchase.repository;
+
+import com.querydsl.core.BooleanBuilder;
+import com.querydsl.jpa.impl.JPAQueryFactory;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
+import org.springframework.data.domain.Pageable;
+import renewal.awesome_travel_backoffice.airPurchase.dto.request.AirPurchaseSearchCondition;
+import renewal.awesome_travel_backoffice.airPurchase.entity.AirPurchase;
+import renewal.awesome_travel_backoffice.airPurchase.entity.QAirPurchase;
+
+import java.util.List;
+
+@RequiredArgsConstructor
+public class AirPurchaseRepositoryCustomImpl implements AirPurchaseRepositoryCustom {
+
+    private final JPAQueryFactory queryFactory;
+
+    @Override
+    public Page<AirPurchase> searchByCondition(AirPurchaseSearchCondition cond, Pageable pageable) {
+        QAirPurchase q = QAirPurchase.airPurchase;
+
+        BooleanBuilder builder = new BooleanBuilder();
+
+        if (cond.getStatus() != null) {
+            builder.and(q.purchaseStatus.eq(cond.getStatus()));
+        }
+        if (cond.getName() != null && !cond.getName().isBlank()) {
+            builder.and(q.name.containsIgnoreCase(cond.getName()));
+        }
+        if (cond.getEmail() != null && !cond.getEmail().isBlank()) {
+            builder.and(q.email.containsIgnoreCase(cond.getEmail()));
+        }
+        if (cond.getStartDate() != null) {
+            builder.and(q.purchaseDate.goe(cond.getStartDate().atStartOfDay()));
+        }
+        if (cond.getEndDate() != null) {
+            builder.and(q.purchaseDate.loe(cond.getEndDate().atTime(23, 59, 59)));
+        }
+
+        List<AirPurchase> results = queryFactory.selectFrom(q)
+                .where(builder)
+                .offset(pageable.getOffset())
+                .limit(pageable.getPageSize())
+                .orderBy(q.purchaseDate.desc())
+                .fetch();
+
+        Long count = queryFactory.select(q.count())
+                .from(q)
+                .where(builder)
+                .fetchOne();
+
+        return new PageImpl<>(results, pageable, count);
+    }
+}
+

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/service/AirPurchaseService.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/service/AirPurchaseService.java
@@ -1,0 +1,147 @@
+package renewal.awesome_travel_backoffice.airPurchase.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import renewal.awesome_travel_backoffice.air.dto.response.AirResponseDto;
+import renewal.awesome_travel_backoffice.air.entity.Air;
+import renewal.awesome_travel_backoffice.air.entity.SeatClass;
+import renewal.awesome_travel_backoffice.airPurchase.dto.request.AirPurchaseSearchCondition;
+import renewal.awesome_travel_backoffice.airPurchase.dto.response.AirPassengerResponseDto;
+import renewal.awesome_travel_backoffice.airPurchase.dto.response.AirPurchaseResponseDto;
+import renewal.awesome_travel_backoffice.airPurchase.dto.response.AirResponseOneDto;
+import renewal.awesome_travel_backoffice.airPurchase.entity.AirPurchase;
+import renewal.awesome_travel_backoffice.airPurchase.repository.AirPurchaseRepository;
+import renewal.awesome_travel_backoffice.airPurchase.utiles.PurchaseStatus;
+import renewal.awesome_travel_backoffice.specialRequest.entity.SpecialRequest;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class AirPurchaseService {
+
+    private final AirPurchaseRepository airPurchaseRepository;
+
+    /**
+     *  어드민 - 전체 항공 예약 목록 조회 (페이징 + 정렬)
+     */
+    public Page<AirPurchaseResponseDto> getAllPurchases(AirPurchaseSearchCondition condition, Pageable pageable) {
+        return airPurchaseRepository.searchByCondition(condition, pageable)
+                .map(this::toDto);
+    }
+
+
+    /**
+     *  어드민 - 단건 예약 상세 조회
+     */
+    public AirPurchaseResponseDto getPurchase(Long id) {
+        AirPurchase purchase = airPurchaseRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("구매 내역 없음"));
+        return toDto(purchase);
+    }
+
+    // 관리자용 - 상태 변경
+    @Transactional
+    public void changePurchaseStatus(Long id, PurchaseStatus newStatus) {
+        AirPurchase purchase = airPurchaseRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("구매 내역 없음"));
+
+        PurchaseStatus currentStatus = purchase.getPurchaseStatus();
+
+        // 동일 상태로의 변경 차단
+        if (currentStatus == newStatus) {
+            throw new IllegalStateException("이미 해당 상태입니다.");
+        }
+
+        // PAID → CANCELLED 같은 위험한 전이 차단 (선택)
+        if (currentStatus == PurchaseStatus.PAID && newStatus == PurchaseStatus.CANCELLED) {
+            throw new IllegalStateException("결제 완료된 예약은 취소할 수 없습니다.");
+        }
+
+        // CANCELLED → PAID 같은 재확정도 차단 (선택)
+        if (currentStatus == PurchaseStatus.CANCELLED && newStatus == PurchaseStatus.PAID) {
+            throw new IllegalStateException("취소된 예약은 다시 확정할 수 없습니다.");
+        }
+
+        // 좌석 수 복구: HOLDING or PAID → CANCELLED
+        if ((currentStatus == PurchaseStatus.HOLDING || currentStatus == PurchaseStatus.PAID)
+                && newStatus == PurchaseStatus.CANCELLED) {
+            SeatClass seatClass = purchase.getSeatClass();
+            seatClass.increaseAvailableSeats(purchase.getAirPassengers().size());
+        }
+
+        // 상태 변경 적용
+        purchase.setPurchaseStatus(newStatus);
+
+        // 로그 (예: 실제로는 DB에 남기거나 파일에 기록 가능)
+        System.out.printf("[관리자] 예약 상태 변경: ID=%d | %s → %s | 시간=%s\n",
+                purchase.getId(), currentStatus, newStatus, LocalDateTime.now());
+    }
+
+    /**
+     *  내부 변환 메서드 (응답용 DTO로 변환)
+     */
+    private AirPurchaseResponseDto toDto(AirPurchase purchase) {
+        SeatClass seatClass = purchase.getSeatClass();
+        Air air = seatClass.getAir();
+
+        //유저기능과 달리 AirResponseDto의 구조가 다르기 떄문에 AirResponseOneDto로 변경해서 보여줌
+        //어드민에서의 AirResponse는 항공하나의 리턴이 아닌 seatclass전체를 리턴하기 때문에 차이가 있음
+        AirResponseOneDto airDto = AirResponseOneDto.builder()
+                .airId(air.getId())
+                .code(air.getCode())
+                .airlineCode(air.getAirline().getCode())
+                .airlineNameKor(air.getAirline().getNameKor())
+                .airlineNameEng(air.getAirline().getNameEng())
+                .depart(air.getDepart())
+                .arrive(air.getArrive())
+                .departTime(air.getDepart_time())
+                .arriveTime(air.getArrive_time())
+                .stopovers(air.getStopovers())
+                .flightType(air.getFlightType())
+                .seatClassId(seatClass.getId())
+                .seatClassType(seatClass.getClassType())
+                .price(seatClass.getPrice())
+                .availableSeats(seatClass.getAvailableSeats())
+                .build();
+
+        List<AirPassengerResponseDto> passengerDtos = purchase.getAirPassengers().stream()
+                .map(passenger -> {
+                    List<String> requestList = passenger.getSpecialRequests().stream()
+                            .map(SpecialRequest::getRequestType)
+                            .toList();
+                    return new AirPassengerResponseDto(
+                            passenger.getName(),
+                            passenger.getNumber(),
+                            passenger.getEmail(),
+                            passenger.getBirth(),
+                            passenger.getSex().name(),
+                            passenger.getNationality().getCountryCode(),
+                            passenger.getPassport_num(),
+                            passenger.getLastName(),
+                            passenger.getFirstName(),
+                            passenger.getExpire(),
+                            requestList
+                    );
+                }).toList();
+
+        return new AirPurchaseResponseDto(
+                purchase.getId(),
+                airDto,
+                purchase.getPurchaseStatus(),
+                purchase.getPrice(),
+                purchase.getMember_id(),
+                purchase.getName(),
+                purchase.getNumber(),
+                purchase.getEmail(),
+                purchase.getPurchaseDate(),
+                purchase.getPaymentDueDate(),
+                passengerDtos
+        );
+    }
+}
+

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/utiles/PurchaseStatus.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/utiles/PurchaseStatus.java
@@ -1,0 +1,7 @@
+package renewal.awesome_travel_backoffice.airPurchase.utiles;
+
+public enum PurchaseStatus {
+    HOLDING,    // 결제 대기 상태
+    PAID,       // 결제 완료
+    CANCELLED   // 결제 실패 또는 시간 초과
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/airPurchase/utiles/Sex.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/airPurchase/utiles/Sex.java
@@ -1,0 +1,6 @@
+package renewal.awesome_travel_backoffice.airPurchase.utiles;
+
+public enum Sex {
+    male,
+    female
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/country/controller/CountryAdminController.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/country/controller/CountryAdminController.java
@@ -1,0 +1,44 @@
+package renewal.awesome_travel_backoffice.country.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import renewal.awesome_travel_backoffice.country.dto.CountryDto;
+import renewal.awesome_travel_backoffice.country.service.CountryService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/countries")
+public class CountryAdminController {
+
+    private final CountryService countryService;
+
+    // 관리자용 전체 조회
+    @GetMapping
+    public ResponseEntity<List<CountryDto>> getAllForAdmin() {
+        return ResponseEntity.ok(countryService.getAllCountries());
+    }
+
+    // 등록
+    @PostMapping
+    public ResponseEntity<String> create(@RequestBody CountryDto dto) {
+        countryService.createCountry(dto);
+        return ResponseEntity.ok(dto.getCountryCode());
+    }
+
+    // 수정
+    @PutMapping("/{countryCode}")
+    public ResponseEntity<Void> update(@PathVariable String countryCode, @RequestBody CountryDto dto) {
+        countryService.updateCountry(countryCode, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 삭제
+    @DeleteMapping("/{countryCode}")
+    public ResponseEntity<Void> delete(@PathVariable String countryCode) {
+        countryService.deleteCountry(countryCode);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/country/dto/CountryDto.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/country/dto/CountryDto.java
@@ -1,0 +1,19 @@
+package renewal.awesome_travel_backoffice.country.dto;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+public class CountryDto {
+
+    private String CountryCode;
+
+    private String CountryName;
+
+    private String CountryNameLocal;
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/country/entity/Country.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/country/entity/Country.java
@@ -1,0 +1,40 @@
+package renewal.awesome_travel_backoffice.country.entity;
+
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.Id;
+import jakarta.persistence.Table;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "Country")
+public class Country {
+
+    @Id
+    @Column(nullable = false, unique = true)
+    private String countryCode; //국가코드 kor
+
+    @Column(nullable = false)
+    private String countryName; //영문 국가명 Republic of Korea
+
+    @Column(nullable = true)
+    private String countryNameLocal; //현지국가명 대한민국
+
+    public Country(String countryCode, String countryName, String countryNameLocal) {
+        this.countryCode = countryCode;
+        this.countryName = countryName;
+        this.countryNameLocal = countryNameLocal;
+    }
+
+    public void updateCountry(String countryName, String countryNameLocal) {
+        if (countryName != null) {
+            this.countryName = countryName;
+        }
+        if (countryNameLocal != null) {
+            this.countryNameLocal = countryNameLocal;
+        }
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/country/repository/CountryRepository.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/country/repository/CountryRepository.java
@@ -1,0 +1,17 @@
+package renewal.awesome_travel_backoffice.country.repository;
+
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import renewal.awesome_travel_backoffice.country.entity.Country;
+
+import java.util.Optional;
+
+public interface CountryRepository extends JpaRepository<Country, String> {
+
+    // 국가 코드(countryCode)로 조회
+    Optional<Country> findByCountryCode(String countryCode);
+
+    // 국가 영문명(countryName)으로 조회
+    Optional<Country> findByCountryName(String countryName);
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/country/service/CountryService.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/country/service/CountryService.java
@@ -1,0 +1,48 @@
+package renewal.awesome_travel_backoffice.country.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import renewal.awesome_travel_backoffice.country.dto.CountryDto;
+import renewal.awesome_travel_backoffice.country.entity.Country;
+import renewal.awesome_travel_backoffice.country.repository.CountryRepository;
+
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+public class CountryService {
+
+    private final CountryRepository countryRepository;
+
+    public List<CountryDto> getAllCountries() {
+        return countryRepository.findAll().stream()
+                .map(c -> new CountryDto(
+                        c.getCountryCode(),
+                        c.getCountryName(),
+                        c.getCountryNameLocal()
+                ))
+                .toList();
+    }
+
+    @Transactional
+    public void createCountry(CountryDto dto) {
+        if (countryRepository.existsById(dto.getCountryCode())) {
+            throw new IllegalArgumentException("이미 존재하는 국가 코드입니다.");
+        }
+        Country country = new Country(dto.getCountryCode(), dto.getCountryName(), dto.getCountryNameLocal());
+        countryRepository.save(country);
+    }
+
+    @Transactional
+    public void updateCountry(String countryCode, CountryDto dto) {
+        Country country = countryRepository.findById(countryCode)
+                .orElseThrow(() -> new IllegalArgumentException("존재하지 않는 국가입니다."));
+        country.updateCountry(dto.getCountryName(), dto.getCountryNameLocal());
+    }
+
+    @Transactional
+    public void deleteCountry(String countryCode) {
+        countryRepository.deleteById(countryCode);
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/specialRequest/controller/SpecialRequestAdminController.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/specialRequest/controller/SpecialRequestAdminController.java
@@ -1,0 +1,45 @@
+package renewal.awesome_travel_backoffice.specialRequest.controller;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+import renewal.awesome_travel_backoffice.specialRequest.dto.SpecialRequestDto;
+import renewal.awesome_travel_backoffice.specialRequest.service.SpecialRequestService;
+
+import java.util.List;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/admin/special-requests")
+public class SpecialRequestAdminController {
+
+    private final SpecialRequestService specialRequestService;
+
+    // 특별요청 등록
+    @PostMapping
+    public ResponseEntity<Long> create(@RequestBody SpecialRequestDto dto) {
+        Long id = specialRequestService.createRequest(dto);
+        return ResponseEntity.ok(id);
+    }
+
+    // 관리자용 - 전체 목록 조회
+    @GetMapping
+    public ResponseEntity<List<SpecialRequestDto>> getAll() {
+        List<SpecialRequestDto> list = specialRequestService.getAllForAdmin();
+        return ResponseEntity.ok(list);
+    }
+
+    // 특별요청 수정
+    @PutMapping("/{id}")
+    public ResponseEntity<Void> update(@PathVariable Long id, @RequestBody SpecialRequestDto dto) {
+        specialRequestService.updateRequest(id, dto);
+        return ResponseEntity.ok().build();
+    }
+
+    // 특별요청 삭제
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> delete(@PathVariable Long id) {
+        specialRequestService.deleteRequest(id);
+        return ResponseEntity.noContent().build();
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/specialRequest/dto/SpecialRequestDto.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/specialRequest/dto/SpecialRequestDto.java
@@ -1,0 +1,21 @@
+package renewal.awesome_travel_backoffice.specialRequest.dto;
+
+import com.fasterxml.jackson.annotation.JsonInclude;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.Setter;
+
+@Getter
+@Setter
+@AllArgsConstructor
+@NoArgsConstructor
+@JsonInclude(JsonInclude.Include.NON_NULL)
+public class SpecialRequestDto {
+
+    private Long id;
+
+    private String requestType;
+
+    private String description;
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/specialRequest/entity/SpecialRequest.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/specialRequest/entity/SpecialRequest.java
@@ -1,0 +1,32 @@
+package renewal.awesome_travel_backoffice.specialRequest.entity;
+
+import jakarta.persistence.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Getter
+@NoArgsConstructor
+@Table(name = "specialRequest")
+public class SpecialRequest {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false, unique = true)
+    private String requestType; //요청유형(휠체어, 추가수하물, 유아용좌석, 채식주의자, 의료지원 등등)
+
+    @Column(nullable = true)
+    private String description; //요청설명
+
+    public SpecialRequest(String requestType, String description) {
+        this.requestType = requestType;
+        this.description = description;
+    }
+
+    public void update(String requestType, String description) {
+        if (requestType != null) this.requestType = requestType;
+        if (description != null) this.description = description;
+    }
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/specialRequest/repository/SpecialRequestRepository.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/specialRequest/repository/SpecialRequestRepository.java
@@ -1,0 +1,8 @@
+package renewal.awesome_travel_backoffice.specialRequest.repository;
+
+
+import org.springframework.data.jpa.repository.JpaRepository;
+import renewal.awesome_travel_backoffice.specialRequest.entity.SpecialRequest;
+
+public interface SpecialRequestRepository extends JpaRepository<SpecialRequest, Long> {
+}

--- a/src/main/java/renewal/awesome_travel_backoffice/specialRequest/service/SpecialRequestService.java
+++ b/src/main/java/renewal/awesome_travel_backoffice/specialRequest/service/SpecialRequestService.java
@@ -1,0 +1,52 @@
+package renewal.awesome_travel_backoffice.specialRequest.service;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.web.bind.annotation.GetMapping;
+import renewal.awesome_travel_backoffice.specialRequest.dto.SpecialRequestDto;
+import renewal.awesome_travel_backoffice.specialRequest.entity.SpecialRequest;
+import renewal.awesome_travel_backoffice.specialRequest.repository.SpecialRequestRepository;
+
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class SpecialRequestService {
+
+    private final SpecialRequestRepository specialRequestRepository;
+
+    // 관리자용 - 특별요청 등록
+    @Transactional
+    public Long createRequest(SpecialRequestDto dto) {
+        SpecialRequest request = new SpecialRequest(dto.getRequestType(), dto.getDescription());
+        return specialRequestRepository.save(request).getId();
+    }
+
+    // 관리자용 - 전체 요청 조회
+    public List<SpecialRequestDto> getAllForAdmin() {
+        return specialRequestRepository.findAll().stream()
+                .map(req -> new SpecialRequestDto(
+                        req.getId(),
+                        req.getRequestType(),
+                        req.getDescription()
+                ))
+                .collect(Collectors.toList());
+    }
+
+    // 관리자용 - 특별요청 수정
+    @Transactional
+    public void updateRequest(Long id, SpecialRequestDto dto) {
+        SpecialRequest request = specialRequestRepository.findById(id)
+                .orElseThrow(() -> new IllegalArgumentException("요청 항목이 존재하지 않습니다."));
+        request.update(dto.getRequestType(), dto.getDescription());
+    }
+
+    // 관리자용 - 특별요청 삭제
+    @Transactional
+    public void deleteRequest(Long id) {
+        specialRequestRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
항공 구매 서비스 전체 어드민 기능 구상
정렬 필터는 querydsl로 처리함
기존 유저와 dto가 다른부분은 AirResponseDto를 AirResponseOneDto로 변경함
왜냐하면 기존 air들어있는 dto와 리턴할 내용이 다르기때문 유저는 단일 항공 어드민은 전체 좌석이 리턴
AirPassenger변경기능은 없지만 추후 필요시 기능 구현